### PR TITLE
Update Jenkins minimum version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>plugin</artifactId>
-      <version>4.0</version>
+      <version>4.38</version>
     <relativePath />
   </parent>
 
@@ -45,7 +45,7 @@
   </scm>
 
   <properties>
-    <jenkins.version>2.204.2</jenkins.version>
+    <jenkins.version>2.303.1</jenkins.version>
     <java.level>8</java.level>
     <workflow-jenkins-plugin.version>1.11</workflow-jenkins-plugin.version>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
@@ -80,8 +80,8 @@
       <!-- https://mvnrepository.com/artifact/io.jenkins.tools.bom/bom-2.164.x -->
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
-        <artifactId>bom-2.204.x</artifactId>
-        <version>13</version>
+        <artifactId>bom-2.303.x</artifactId>
+        <version>1198.v387c834fca_1a_</version>
         <!--<scope>import</scope>-->
         <type>pom</type>
       </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -71,18 +71,21 @@
       <groupId>org.jenkins-ci.main</groupId>
       <artifactId>maven-plugin</artifactId>
       <version>3.5</version>
-      <type>jar</type>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-digester3</artifactId>
+      <version>3.2</version>
     </dependency>
   </dependencies>
   
  <dependencyManagement>
     <dependencies>
-      <!-- https://mvnrepository.com/artifact/io.jenkins.tools.bom/bom-2.164.x -->
+      <!-- https://mvnrepository.com/artifact/io.jenkins.tools.bom/bom-2.303q.x -->
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
         <artifactId>bom-2.303.x</artifactId>
         <version>1198.v387c834fca_1a_</version>
-        <!--<scope>import</scope>-->
         <type>pom</type>
       </dependency>
       <dependency>
@@ -90,21 +93,16 @@
           <artifactId>commons-lang3</artifactId>
           <version>3.9</version>
       </dependency>
-      <!--<dependency>
-          <groupId>org.slf4j</groupId>
-          <artifactId>log4j-over-slf4j</artifactId>
-          <version>1.7.26</version>
+      <dependency>
+        <groupId>org.jenkins-ci</groupId>
+        <artifactId>symbol-annotation</artifactId>
+        <version>1.2</version>
       </dependency>
       <dependency>
-          <groupId>org.slf4j</groupId>
-          <artifactId>jcl-over-slf4j</artifactId>
-          <version>1.7.26</version>
+        <groupId>commons-net</groupId>
+        <artifactId>commons-net</artifactId>
+        <version>3.8.0</version>
       </dependency>
-      <dependency>
-          <groupId>org.slf4j</groupId>
-          <artifactId>slf4j-jdk14</artifactId>
-          <version>1.7.26</version>
-      </dependency>-->
   </dependencies>
 </dependencyManagement>
   <build>
@@ -112,20 +110,20 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.0</version>
+        <version>3.8.1</version>
         <configuration>
           <source>1.8</source>
           <target>1.8</target>
           <showDeprecation>true</showDeprecation>
         </configuration>
       </plugin>
-               <plugin>
-                    <groupId>org.jenkins-ci.tools</groupId>
-                    <artifactId>maven-hpi-plugin</artifactId>
-                    <configuration>
-                        <disabledTestInjection>true</disabledTestInjection>
-                    </configuration>
-                </plugin>
+      <plugin>
+          <groupId>org.jenkins-ci.tools</groupId>
+          <artifactId>maven-hpi-plugin</artifactId>
+          <configuration>
+              <disabledTestInjection>true</disabledTestInjection>
+          </configuration>
+      </plugin>
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>build-helper-maven-plugin</artifactId>

--- a/src/main/java/hudson/plugins/cocoemma/CoverageReport.java
+++ b/src/main/java/hudson/plugins/cocoemma/CoverageReport.java
@@ -1,7 +1,8 @@
 package hudson.plugins.cocoemma;
 
 import hudson.model.AbstractBuild;
-import org.apache.commons.digester.Digester;
+import org.apache.commons.digester3.Digester;
+import javax.xml.parsers.ParserConfigurationException;
 import org.xml.sax.SAXException;
 
 import java.io.File;
@@ -25,7 +26,7 @@ public final class CoverageReport extends AggregatedReport<CoverageReport/*dummy
         this(action);
         for (InputStream is: xmlReports) {
           try {
-            createDigester().parse(is);
+            createDigester(!Boolean.getBoolean(this.getClass().getName() + ".UNSAFE")).parse(is);
           } catch (SAXException e) {
               throw new IOException("Failed to parse XML",e);
           }
@@ -36,7 +37,7 @@ public final class CoverageReport extends AggregatedReport<CoverageReport/*dummy
     public CoverageReport(EmmaBuildAction action, File xmlReport) throws IOException {
         this(action);
         try {
-            createDigester().parse(xmlReport);
+            createDigester(!Boolean.getBoolean(this.getClass().getName() + ".UNSAFE")).parse(xmlReport);
         } catch (SAXException e) {
             throw new IOException("Failed to parse "+xmlReport,e);
         }
@@ -60,8 +61,20 @@ public final class CoverageReport extends AggregatedReport<CoverageReport/*dummy
     /**
      * Creates a configured {@link Digester} instance for parsing report XML.
      */
-    private Digester createDigester() {
+    private Digester createDigester(boolean secure) throws SAXException {
         Digester digester = new Digester();
+
+        if (secure) {
+            digester.setXIncludeAware(false);
+            try {
+                digester.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+                digester.setFeature("http://xml.org/sax/features/external-general-entities", false);
+                digester.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+                digester.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
+            } catch (ParserConfigurationException ex) {
+                throw new SAXException("Failed to securely configure xml digester parser", ex);
+            }
+        }
         digester.setClassLoader(getClass().getClassLoader());
 
         digester.push(this);


### PR DESCRIPTION
Update the minimum Jenkins version to one recommended in the Jenkins plugin dev guide (https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/). Along with this change, the parent pom and BOM versions were updated.
This update required some additional dependency updates including moving to digester3(https://github.com/jenkinsci/jenkins/pull/5320)
